### PR TITLE
Named captures were introduced in Perl 5.10

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,6 +8,7 @@ WriteMakefile(
     VERSION_FROM        => 'lib/Text/Substitute.pm',
     ABSTRACT_FROM       => 'lib/Text/Substitute.pm',
     PL_FILES            => {},
+    MIN_PERL_VERSION    => "5.010",
     CONFIGURE_REQUIRES => {
         "ExtUtils::MakeMaker" => 6.5503,
     },


### PR DESCRIPTION
The regexes in the code use named captures. As they were introduced in Perl 5.10, the Makefile.PL should set the minimum required Perl version.